### PR TITLE
Ai tutor jitpack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -157,7 +157,11 @@ dependencies {
     ksp 'io.github.raamcosta.compose-destinations:ksp:1.9.54'
 
     // AI Tutor
-    implementation 'org.catrobat:aitutor:0.0.1'
+    implementation('com.github.Catrobat:catrobat-ai-tutor:develop-SNAPSHOT') {
+        // Choose one of the following to exclude either debug or release variant
+//        exclude group: 'com.github.Catrobat.catrobat-ai-tutor', module: 'aitutor-android-debug'
+        exclude group: 'com.github.Catrobat.catrobat-ai-tutor', module: 'aitutor-android'
+    }
 
     // Test
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
This pull request updates the AI Tutor library dependency in the project's Gradle build configuration. The new dependency points to a SNAPSHOT version from JitPack and explicitly excludes a specific module to control which variant is included in the build.